### PR TITLE
ci: update github actions to latest version

### DIFF
--- a/.github/workflows/sched-template-sync.yml
+++ b/.github/workflows/sched-template-sync.yml
@@ -25,7 +25,7 @@ jobs:
         #   submodules: true
 
       - name: actions-template-sync
-        uses: AndreasAugustin/actions-template-sync@v1.5.0
+        uses: AndreasAugustin/actions-template-sync@v2.0.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: ac-analytics/python-package-template


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[AndreasAugustin/actions-template-sync](https://github.com/AndreasAugustin/actions-template-sync)** published a new release **[v2.0.1](https://github.com/AndreasAugustin/actions-template-sync/releases/tag/v2.0.1)** on 2024-03-18T21:40:26Z
