### PR TITLE
ci: update github actions to latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   validation:
-    uses: ac-analytics/action-python/.github/workflows/validation.yml@v0.1.1
+    uses: ac-analytics/action-python/.github/workflows/validation.yml@v0.1.3
     with:
       workdir: '.'
       testdir: 'tests'

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -12,6 +12,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.4.0
+      - uses: amannn/action-semantic-pull-request@v5.5.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   publish:
-    uses: ac-analytics/action-python/.github/workflows/publish.yml@v0.1.1
+    uses: ac-analytics/action-python/.github/workflows/publish.yml@v0.1.3
     secrets:
       PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       TEST_PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD  }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,4 +4,4 @@ on:
 
 jobs:
   release:
-    uses: ac-analytics/action-python/.github/workflows/release.yml@v0.1.1
+    uses: ac-analytics/action-python/.github/workflows/release.yml@v0.1.3

--- a/.github/workflows/sched-actions-update.yml
+++ b/.github/workflows/sched-actions-update.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.5
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/sched-template-sync.yml
+++ b/.github/workflows/sched-template-sync.yml
@@ -18,14 +18,14 @@ jobs:
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.5
         # https://github.com/actions/checkout#usage
         # uncomment if you use submodules within the source repository
         # with:
         #   submodules: true
 
       - name: actions-template-sync
-        uses: AndreasAugustin/actions-template-sync@v1.5.0
+        uses: AndreasAugustin/actions-template-sync@v2.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: ac-analytics/python-package-template

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -15,4 +15,4 @@ jobs:
       id-token: write
     steps:
     - id: deployment
-      uses: sphinx-notes/pages@v3
+      uses: sphinx-notes/pages@3.1


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.5](https://github.com/actions/checkout/releases/tag/v4.1.5)** on 2024-05-06T17:39:01Z
* **[ac-analytics/action-python](https://github.com/ac-analytics/action-python)** published a new release **[v0.1.3](https://github.com/ac-analytics/action-python/releases/tag/v0.1.3)** on 2024-05-03T04:06:46Z
* **[sphinx-notes/pages](https://github.com/sphinx-notes/pages)** published a new release **[3.1](https://github.com/sphinx-notes/pages/releases/tag/3.1)** on 2024-05-04T16:25:03Z
* **[amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request)** published a new release **[v5.5.2](https://github.com/amannn/action-semantic-pull-request/releases/tag/v5.5.2)** on 2024-04-24T15:08:49Z
* **[AndreasAugustin/actions-template-sync](https://github.com/AndreasAugustin/actions-template-sync)** published a new release **[v2.1.0](https://github.com/AndreasAugustin/actions-template-sync/releases/tag/v2.1.0)** on 2024-04-23T19:15:29Z
