### PR TITLE
ci: update github actions to latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   validation:
-    uses: altcoder/action-python/.github/workflows/validation.yml@v0.1
+    uses: altcoder/action-python/.github/workflows/validation.yml@v0.1.3
     with:
       workdir: '.'
       testdir: 'tests'

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -12,6 +12,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.5.2
+      - uses: amannn/action-semantic-pull-request@v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   publish:
-    uses: altcoder/action-python/.github/workflows/publish.yml@v0.1
+    uses: altcoder/action-python/.github/workflows/publish.yml@v0.1.3
     secrets:
       PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       TEST_PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD  }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,4 +4,4 @@ on:
 
 jobs:
   release:
-    uses: altcoder/action-python/.github/workflows/release.yml@v0.1
+    uses: altcoder/action-python/.github/workflows/release.yml@v0.1.3

--- a/.github/workflows/sched-actions-update.yml
+++ b/.github/workflows/sched-actions-update.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.7
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/sched-template-sync.yml
+++ b/.github/workflows/sched-template-sync.yml
@@ -18,14 +18,14 @@ jobs:
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.7
         # https://github.com/actions/checkout#usage
         # uncomment if you use submodules within the source repository
         # with:
         #   submodules: true
 
       - name: actions-template-sync
-        uses: AndreasAugustin/actions-template-sync@v2.1.0
+        uses: AndreasAugustin/actions-template-sync@v2.2.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: ac-analytics/python-package-template


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[AndreasAugustin/actions-template-sync](https://github.com/AndreasAugustin/actions-template-sync)** published a new release **[v2.2.3](https://github.com/AndreasAugustin/actions-template-sync/releases/tag/v2.2.3)** on 2024-06-19T19:40:10Z
* **[altcoder/action-python](https://github.com/altcoder/action-python)** published a new release **[v0.1.3](https://github.com/altcoder/action-python/releases/tag/v0.1.3)** on 2024-05-03T04:36:23Z
* **[amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request)** published a new release **[v5.5.3](https://github.com/amannn/action-semantic-pull-request/releases/tag/v5.5.3)** on 2024-06-28T07:05:47Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
